### PR TITLE
[Feature] Add ability to maintain directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ enum Sex {
 }
 ```
 
-Will result in two `.avsc` files; `Person.avsc` and `Sex.avsc`. 
+Will result in two `.avsc` files; `Person.avsc` and `Sex.avsc`.
 The `Person.avsc` file will be **self-contained** and not depend on `Sex.avsc`.
 
 If you only want one single file you can declare a main schema as such:
@@ -57,6 +57,7 @@ enum Sex {
 	FEMALE
 }
 ```
+
 This will only output self-contained `Person.avsc` file.
 
 Add the plugin to your `pom.xml`
@@ -64,20 +65,20 @@ Add the plugin to your `pom.xml`
 ```xml
 
 <plugin>
-  <groupId>io.jonasg</groupId>
-  <artifactId>avdl-to-avsc-maven-plugin</artifactId>
-  <version>${avdl-to-avsc-maven-plugin.version}</version>
-  <executions>
-    <execution>
-      <goals>
-        <goal>avdl-to-avsc</goal>
-      </goals>
-      <configuration>
-        <avdlDirectory>${avdl.dir}</avdlDirectory>
-        <avscDirectory>${project.build.directory}/generated-sources/avsc</avscDirectory>
-      </configuration>
-    </execution>
-  </executions>
+    <groupId>io.jonasg</groupId>
+    <artifactId>avdl-to-avsc-maven-plugin</artifactId>
+    <version>${avdl-to-avsc-maven-plugin.version}</version>
+    <executions>
+        <execution>
+            <goals>
+                <goal>avdl-to-avsc</goal>
+            </goals>
+            <configuration>
+                <avdlDirectory>${avdl.dir}</avdlDirectory>
+                <avscDirectory>${project.build.directory}/generated-sources/avsc</avscDirectory>
+            </configuration>
+        </execution>
+    </executions>
 </plugin>
 ```
 
@@ -86,15 +87,65 @@ Add the plugin to your `pom.xml`
 ```xml
 
 <plugins>
-  <plugin>
-    <groupId>io.confluent</groupId>
-    <artifactId>kafka-schema-registry-maven-plugin</artifactId>
-    <version>${confluent.version}</version>
-    <configuration>
-      <subjects>
-        <my-subject>target/generated-sources/avsc/Event.avsc</my-subject>
-      </subjects>
-    </configuration>
-  </plugin>
+    <plugin>
+        <groupId>io.confluent</groupId>
+        <artifactId>kafka-schema-registry-maven-plugin</artifactId>
+        <version>${confluent.version}</version>
+        <configuration>
+            <subjects>
+                <my-subject>target/generated-sources/avsc/Event.avsc</my-subject>
+            </subjects>
+        </configuration>
+    </plugin>
 </plugins>
+```
+
+## Porting AVDL directory structure to the AVSC output
+
+the plugin `maintainDirectoryStructure` configuration option allows you to maintain the directory structure of your AVDL
+files in the output AVSC directory. When set to `true`, the plugin will create subdirectories in the output AVSC
+directory
+that mirror the structure of the input AVDL directory.
+
+given the following plugin configuration :
+
+```xml
+
+<plugin>
+    <groupId>io.jonasg</groupId>
+    <artifactId>avdl-to-avsc-maven-plugin</artifactId>
+    <version>${avdl-to-avsc-maven-plugin.version}</version>
+    <executions>
+        <execution>
+            <goals>
+                <goal>avdl-to-avsc</goal>
+            </goals>
+            <configuration>
+                <avdlDirectory>src/main/resources/avdl</avdlDirectory>
+                <avscDirectory>${project.build.directory}/generated-sources/avsc</avscDirectory>
+                <maintainDirectoryStructure>true</maintainDirectoryStructure>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>   
+```
+
+And the AVDL source directory structure :
+
+```src/main/resources/avdl
+├── user
+│   ├── User.avdl
+│   └── Address.avdl
+└── order
+    └── Order.avdl
+``` 
+
+The plugin will generate the below AVSC directory structure:
+
+```target/generated-sources/avsc
+├── user
+│   ├── User.avsc
+│   └── Address.avsc
+└── order
+    └── Order.avsc
 ```

--- a/src/main/java/io/jonasg/avro/AvdlToAvscConverter.java
+++ b/src/main/java/io/jonasg/avro/AvdlToAvscConverter.java
@@ -1,6 +1,7 @@
 package io.jonasg.avro;
 
-import static java.nio.file.Files.walk;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.maven.plugin.logging.Log;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,12 +11,12 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import org.apache.commons.io.FilenameUtils;
-import org.apache.maven.plugin.logging.Log;
+import static java.nio.file.Files.walk;
 
 public class AvdlToAvscConverter {
 
-    private final IdlToSchemataTool idlToSchemataTool  = new IdlToSchemataTool();;
+    private final IdlToSchemataTool idlToSchemataTool = new IdlToSchemataTool();
+    ;
 
     private final Log log;
 
@@ -23,17 +24,22 @@ public class AvdlToAvscConverter {
         this.log = log;
     }
 
-    public void convert(String avdlDirectory, String avscDirectory) {
-        Path avdlPath = new File(avdlDirectory).toPath();
-        if (!avdlPath.toFile().exists()) {
-            log.error("Avdl directory does not exist: " + avdlPath);
+    public void convert(ConverterConfiguration configuration) {
+        if (!configuration.avdlPath().toFile().exists()) {
+            log.error("Avdl directory does not exist: " + configuration.avdlPath());
             return;
         }
 
-        try(Stream<Path> stream = walk(avdlPath)) {
+        try (Stream<Path> stream = walk(configuration.avdlPath())) {
             stream
                     .filter(this::onAvdlExtension)
-                    .forEach(avdlFile -> avdlToAvsc(avdlFile, new File(avscDirectory)));
+                    .forEach(avdlFile -> {
+                        var relativeAvdlPath = configuration.avdlPath().relativize(avdlFile.getParent());
+                        var outputDirectory = configuration.maintainDirectoryStructure()
+                                ? configuration.avscPath().resolve(relativeAvdlPath)
+                                : configuration.avscPath();
+                        avdlToAvsc(avdlFile, outputDirectory.toFile());
+                    });
 
         } catch (IOException e) {
             log.error("Error walking avdl directory", e);

--- a/src/main/java/io/jonasg/avro/AvdlToAvscMojo.java
+++ b/src/main/java/io/jonasg/avro/AvdlToAvscMojo.java
@@ -5,6 +5,8 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
+import java.nio.file.Path;
+
 @Mojo(name = "avdl-to-avsc", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 @SuppressWarnings("unused")
 public class AvdlToAvscMojo extends AbstractMojo {
@@ -22,13 +24,27 @@ public class AvdlToAvscMojo extends AbstractMojo {
      * Directory where to output the Avro schemas (.avsc)
      *
      * @parameter property="avscOutputDirectory"
-     *            default-value="${project.build.directory}/generated-resources/avro"
+     * default-value="${project.build.directory}/generated-resources/avro"
      */
     @Parameter(property = "avscDirectory", required = true)
     private String avscDirectory;
 
+    /**
+     * Port the directory structure of the avdl files into the corresponding avsc output directory
+     *
+     * @parameter property="maintainDirectoryStructure"
+     * default-value="false"
+     */
+    @Parameter(property = "maintainDirectoryStructure", required = false, defaultValue = "false")
+    private boolean maintainDirectoryStructure;
+
     @Override
     public void execute() {
-        new AvdlToAvscConverter(getLog()).convert(avdlDirectory, avscDirectory);
+        ConverterConfiguration configuration = new ConverterConfiguration(
+                Path.of(avdlDirectory),
+                Path.of(avscDirectory),
+                maintainDirectoryStructure);
+
+        new AvdlToAvscConverter(getLog()).convert(configuration);
     }
 }

--- a/src/main/java/io/jonasg/avro/ConverterConfiguration.java
+++ b/src/main/java/io/jonasg/avro/ConverterConfiguration.java
@@ -1,0 +1,6 @@
+package io.jonasg.avro;
+
+import java.nio.file.Path;
+
+public record ConverterConfiguration(Path avdlPath, Path avscPath, boolean maintainDirectoryStructure) {
+}

--- a/src/test/java/io/jonasg/avro/AvdlToAvscConverterTest.java
+++ b/src/test/java/io/jonasg/avro/AvdlToAvscConverterTest.java
@@ -1,30 +1,38 @@
 package io.jonasg.avro;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.contains;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import org.apache.commons.io.file.DeletingPathVisitor;
+import org.apache.maven.plugin.logging.Log;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.apache.maven.plugin.logging.Log;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.apache.commons.io.file.Counters.noopPathCounters;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 class AvdlToAvscConverterTest {
 
     private Log log;
 
     private AvdlToAvscConverter converter;
+    private Path tempOutputDir;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         log = mock(Log.class);
         converter = new AvdlToAvscConverter(log);
+        tempOutputDir = Files.createTempDirectory("avdl-output");
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @AfterEach
+    void cleanUp() throws Exception {
+        Files.walkFileTree(tempOutputDir, new DeletingPathVisitor(noopPathCounters()));
     }
 
     @Test
@@ -32,43 +40,67 @@ class AvdlToAvscConverterTest {
         String nonExistentDirectory = "non-existent-dir";
         String outputDirectory = "output-dir";
 
-        converter.convert(nonExistentDirectory, outputDirectory);
+        converter.convert(configuration(nonExistentDirectory, outputDirectory, false));
 
         verify(log).error("Avdl directory does not exist: " + Path.of(nonExistentDirectory));
     }
 
     @Test
-    void convertWithValidAvdlFiles() throws IOException {
-        Path tempOutputDir = Files.createTempDirectory("avdl-output");
+    void convertWithValidAvdlFiles() {
 
-        converter.convert("src/test/resources/avdl-input", tempOutputDir.toString());
+
+        converter.convert(configuration("src/test/resources/avdl-input", tempOutputDir.toString(), false));
 
         verify(log).info(contains("Converted src/test/resources/avdl-input/test.avdl"));
         assertThat(tempOutputDir.toFile().listFiles())
                 .hasSize(1)
                 .extracting(File::getName)
                 .contains("Person.avsc");
-        tempOutputDir.toFile().delete();
     }
 
 
     @Test
-    void mainSchemaOnly() throws IOException {
-        Path tempOutputDir = Files.createTempDirectory("avdl-output");
+    void should_maintain_directory_structure() {
+        converter.convert(configuration("src/test/resources/avdl-maintain-dir", tempOutputDir.toString(), true));
 
-        converter.convert("src/test/resources/avdl-main-only", tempOutputDir.toString());
+        verify(log).info(contains("Converted src/test/resources/avdl-maintain-dir/deep/dir/test.avdl"));
+        verify(log).info(contains("Converted src/test/resources/avdl-maintain-dir/deep/dir2/test.avdl"));
+        verify(log).info(contains("Converted src/test/resources/avdl-maintain-dir/test.avdl"));
+        assertThat(tempOutputDir.toFile().listFiles())
+                .hasSize(2)
+                .extracting(File::getName)
+                .contains("Person.avsc", "deep");
+        assertThat(tempOutputDir.resolve(Path.of("deep/dir")).toFile().listFiles())
+                .hasSize(1)
+                .extracting(File::getName)
+                .contains("Person.avsc");
+        assertThat(tempOutputDir.resolve(Path.of("deep/dir2")).toFile().listFiles())
+                .hasSize(1)
+                .extracting(File::getName)
+                .contains("Person.avsc");
+
+    }
+
+
+    @Test
+    void mainSchemaOnly() {
+
+        converter.convert(configuration("src/test/resources/avdl-main-only", tempOutputDir.toString(), false));
 
         assertThat(tempOutputDir.toFile().listFiles())
                 .hasSize(1)
                 .extracting(File::getName)
                 .contains("Person.avsc");
-        tempOutputDir.toFile().delete();
     }
 
     @Test
     void testConvertWithNoAvdlFiles() throws IOException {
-        converter.convert("src/test/resources/no-avdl-files", "src/test/resources/avdl-output");
+        converter.convert(configuration("src/test/resources/no-avdl-files", "src/test/resources/avdl-output", false));
 
         verify(log, never()).info(contains("Converted"));
+    }
+
+    private ConverterConfiguration configuration(String avdlDirectory, String avscDirectory, boolean maintainDirectoryStructure) {
+        return new ConverterConfiguration(Path.of(avdlDirectory), Path.of(avscDirectory), maintainDirectoryStructure);
     }
 }

--- a/src/test/resources/avdl-maintain-dir/deep/dir/test.avdl
+++ b/src/test/resources/avdl-maintain-dir/deep/dir/test.avdl
@@ -1,0 +1,8 @@
+namespace io.jonasg;
+schema Person;
+
+record Person {
+	string name;
+	int age;
+	string? email;
+}

--- a/src/test/resources/avdl-maintain-dir/deep/dir2/test.avdl
+++ b/src/test/resources/avdl-maintain-dir/deep/dir2/test.avdl
@@ -1,0 +1,8 @@
+namespace io.jonasg;
+schema Person;
+
+record Person {
+	string name;
+	int age;
+	string? email;
+}

--- a/src/test/resources/avdl-maintain-dir/test.avdl
+++ b/src/test/resources/avdl-maintain-dir/test.avdl
@@ -1,0 +1,8 @@
+namespace io.jonasg;
+schema Person;
+
+record Person {
+	string name;
+	int age;
+	string? email;
+}


### PR DESCRIPTION
resolves https://github.com/jonas-grgt/avdl-to-avsc-maven-plugin/issues/1

- add a new boolean parameter enabling to map the avdl file structure when translating them to .avsc in the target directory
- Add a holder record to convey configuration to the `AvdlToAvscConverter` to avoid passing al arguments independently
- Add a test convering the new case